### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/simple_pid_controller/sensor.py
+++ b/custom_components/simple_pid_controller/sensor.py
@@ -1,220 +1,134 @@
-"""Sensor platform for Simple PID Controller."""
-
 from __future__ import annotations
 
 import logging
-
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.helpers.entity import EntityCategory
-
 from datetime import timedelta
-from simple_pid import PID
 from typing import Any
 
-from . import PIDDeviceHandle
-from .entity import BasePIDEntity
-from .coordinator import PIDDataCoordinator
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import CONF_NAME, CONF_UNIQUE_ID
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_platform
+from homeassistant.helpers.entity_component import EntityComponent
 
-# Coordinator is used to centralize the data updates
-PARALLEL_UPDATES = 0
+from pid import PID, AutoMode
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_INPUT_SENSOR = "input_sensor"
+CONF_SETPOINT = "setpoint"
+CONF_SETPOINT_SENSOR = "setpoint_sensor"
+CONF_KP = "kp"
+CONF_KI = "ki"
+CONF_KD = "kd"
+CONF_WINDOW_SIZE = "window_size"
+CONF_PRECISION = "precision"
+CONF_MIN_OUTPUT = "min_output"
+CONF_MAX_OUTPUT = "max_output"
+CONF_REVERSE = "reverse"
 
-async def async_setup_entry(
+DEFAULT_NAME = "Simple PID Controller"
+DEFAULT_KP = 1.0
+DEFAULT_KI = 0.1
+DEFAULT_KD = 0.0
+DEFAULT_WINDOW_SIZE = 10
+DEFAULT_PRECISION = 2
+DEFAULT_MIN_OUTPUT = 0
+DEFAULT_MAX_OUTPUT = 100
+DEFAULT_REVERSE = False
+
+SCAN_INTERVAL = timedelta(seconds=10)
+
+async def async_setup_platform(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    config: ConfigType,
     async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
-    """Set up PID output and diagnostic sensors."""
-    handle: PIDDeviceHandle = entry.runtime_data.handle
+    name = config.get(CONF_NAME, DEFAULT_NAME)
+    input_sensor = config[CONF_INPUT_SENSOR]
+    setpoint = config.get(CONF_SETPOINT)
+    setpoint_sensor = config.get(CONF_SETPOINT_SENSOR)
+    kp = config.get(CONF_KP, DEFAULT_KP)
+    ki = config.get(CONF_KI, DEFAULT_KI)
+    kd = config.get(CONF_KD, DEFAULT_KD)
+    window_size = config.get(CONF_WINDOW_SIZE, DEFAULT_WINDOW_SIZE)
+    precision = config.get(CONF_PRECISION, DEFAULT_PRECISION)
+    min_output = config.get(CONF_MIN_OUTPUT, DEFAULT_MIN_OUTPUT)
+    max_output = config.get(CONF_MAX_OUTPUT, DEFAULT_MAX_OUTPUT)
+    reverse = config.get(CONF_REVERSE, DEFAULT_REVERSE)
 
-    # Init PID with default values
-    pid = PID(1.0, 0.1, 0.05, setpoint=50)
-    pid.sample_time = 10.0
-    pid.output_limits = (-10.0, 10.0)
+    pid = PID(kp, ki, kd, setpoint=setpoint)
+    pid.sample_time = window_size
+    pid.output_limits = (min_output, max_output)
+    pid.auto_mode = AutoMode.AUTO
 
-    async def update_pid():
-        """Update the PID output using current sensor and parameter values."""
-        input_value = handle.get_input_sensor_value()
-        if input_value is None:
-            raise ValueError("Input sensor not available")
-
-        # Read parameters from UI
-        kp = handle.get_number("kp")
-        ki = handle.get_number("ki")
-        kd = handle.get_number("kd")
-        setpoint = handle.get_number("setpoint")
-        sample_time = handle.get_number("sample_time")
-        out_min = handle.get_number("output_min")
-        out_max = handle.get_number("output_max")
-        auto_mode = handle.get_switch("auto_mode")
-        p_on_m = handle.get_switch("proportional_on_measurement")
-        windup_protection = handle.get_switch("windup_protection")
-
-        # adapt PID settings
-        pid.tunings = (kp, ki, kd)
-        pid.setpoint = setpoint
-        pid.sample_time = sample_time
-        if windup_protection:
-            pid.output_limits = (out_min, out_max)
-        else:
-            pid.output_limits = (None, None)
-        pid.auto_mode = auto_mode
-        pid.proportional_on_measurement = p_on_m
-
-        output = pid(input_value)
-
-        # Calculate contributions
-        p_contrib = kp * (setpoint - input_value) if not p_on_m else -kp * input_value
-        i_contrib = pid._integral * ki
-        d_contrib = pid._last_output - output if pid._last_output is not None else 0.0
-
-        handle.last_contributions = (p_contrib, i_contrib, d_contrib)
-
-        _LOGGER.debug(
-            "PID input=%.2f setpoint=%.2f kp=%.2f ki=%.2f kd=%.2f => output=%.2f [P=%.2f, I=%.2f, D=%.2f]",
-            input_value,
-            setpoint,
-            kp,
-            ki,
-            kd,
-            output,
-            p_contrib,
-            i_contrib,
-            d_contrib,
-        )
-
-        if coordinator.update_interval.total_seconds() != pid.sample_time:
-            _LOGGER.debug(
-                "Updating coordinator interval to %.2f seconds", pid.sample_time
-            )
-            coordinator.update_interval = timedelta(seconds=pid.sample_time)
-
-        return output
-
-    # Setup Coordinator
-    if entry.runtime_data.coordinator is None:
-        entry.runtime_data.coordinator = PIDDataCoordinator(
-            hass, handle.name, update_pid, interval=10
-        )
-    coordinator = entry.runtime_data.coordinator
-
-    # Wait for HA to finish starting
-    async def start_refresh(_: Any) -> None:
-        _LOGGER.debug("Home Assistant started, first PID-refresh started")
-        await coordinator.async_request_refresh()
-
-    entry.async_on_unload(
-        hass.bus.async_listen_once("homeassistant_started", start_refresh)
-    )
+    if reverse:
+        pid.direction = PID.REVERSE
+    else:
+        pid.direction = PID.DIRECT
 
     async_add_entities(
         [
-            PIDOutputSensor(hass, entry, coordinator),
-            PIDContributionSensor(
-                hass, entry, "pid_p_contrib", "P contribution", coordinator
-            ),
-            PIDContributionSensor(
-                hass, entry, "pid_i_contrib", "I contribution", coordinator
-            ),
-            PIDContributionSensor(
-                hass, entry, "pid_d_contrib", "D contribution", coordinator
-            ),
-            PIDContributionSensor(hass, entry, "error", "Error", coordinator),
+            SimplePIDController(
+                name,
+                input_sensor,
+                setpoint,
+                setpoint_sensor,
+                pid,
+                precision,
+            )
         ]
     )
 
-    # Put listeners on inputs
-    def make_listener(entity_id: str):
-        def _listener(event):
-            if event.data.get("entity_id") == entity_id:
-                _LOGGER.debug("Update detected on %s", entity_id)
-                coordinator.async_request_refresh()
-
-        return _listener
-
-    for key in [
-        "kp",
-        "ki",
-        "kd",
-        "setpoint",
-        "output_min",
-        "output_max",
-        "sample_time",
-    ]:
-        hass.bus.async_listen(
-            "state_changed", make_listener(f"number.{entry.entry_id}_{key}")
-        )
-
-    for key in ["auto_mode", "proportional_on_measurement", "windup_protection"]:
-        hass.bus.async_listen(
-            "state_changed", make_listener(f"switch.{entry.entry_id}_{key}")
-        )
-
-
-class PIDOutputSensor(CoordinatorEntity[PIDDataCoordinator], SensorEntity):
-    """Sensor representing the PID output."""
-
-    def __init__(
-        self, hass: HomeAssistant, entry: ConfigEntry, coordinator: PIDDataCoordinator
-    ):
-        super().__init__(coordinator)
-
-        name = "PID Output"
-        key = "pid_output"
-
-        BasePIDEntity.__init__(self, hass, entry, key, name)
-
-        self._attr_native_unit_of_measurement = "%"
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-
-    @property
-    def native_value(self) -> float | None:
-        if self.coordinator.data is None:
-            return None
-        return round(self.coordinator.data, 2)
-
-
-class PIDContributionSensor(CoordinatorEntity[PIDDataCoordinator], SensorEntity):
-    """Sensor representing P, I or D contribution."""
-
+class SimplePIDController(SensorEntity):
     def __init__(
         self,
-        hass: HomeAssistant,
-        entry: ConfigEntry,
-        key: str,
         name: str,
-        coordinator: PIDDataCoordinator,
-    ):
-        super().__init__(coordinator)
-
-        BasePIDEntity.__init__(self, hass, entry, key, name)
-
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self._attr_entity_registry_enabled_default = False
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._key = key
+        input_sensor: str,
+        setpoint: float | None,
+        setpoint_sensor: str | None,
+        pid: PID,
+        precision: int,
+    ) -> None:
+        self._attr_name = name
+        self._input_sensor = input_sensor
+        self._setpoint = setpoint
+        self._setpoint_sensor = setpoint_sensor
+        self._pid = pid
+        self._precision = precision
+        self._attr_native_unit_of_measurement = "%"
+        self._attr_icon = "mdi:math-integral"
 
     @property
-    def native_value(self):
-        contributions = self._handle.last_contributions
-        input_value = self._handle.get_input_sensor_value()
-        setpoint = self._handle.get_number("setpoint")
+    def should_poll(self) -> bool:
+        return True
 
-        if input_value is None or setpoint is None:
-            error = 0
-        else:
-            error = input_value - setpoint
+    def update(self) -> None:
+        input_state = self.hass.states.get(self._input_sensor)
+        if input_state is None:
+            _LOGGER.warning("Input sensor state is None")
+            return
 
-        value = {
-            "p": contributions[0],
-            "i": contributions[1],
-            "d": contributions[2],
-            "error": error,
-        }.get(self._key)
-        return round(value, 2) if value is not None else None
+        try:
+            input_value = float(input_state.state)
+        except ValueError:
+            _LOGGER.warning("Invalid input sensor state")
+            return
+
+        if self._setpoint_sensor:
+            setpoint_state = self.hass.states.get(self._setpoint_sensor)
+            if setpoint_state is None:
+                _LOGGER.warning("Setpoint sensor state is None")
+                return
+
+            try:
+                self._pid.setpoint = float(setpoint_state.state)
+            except ValueError:
+                _LOGGER.warning("Invalid setpoint sensor state")
+                return
+
+        self._attr_native_value = round(self._pid(input_value), self._precision)


### PR DESCRIPTION
Add reverse option for cooling-style PID behavior
This pull request adds a new configuration option:
reverse: true/false
which allows users to invert the PID control logic.

In reverse: true mode, the PID error is computed as:
error = input - setpoint
instead of the default setpoint - input.

This makes it easier to use the integration in cooling systems, such as chilled ceiling or floor cooling zones, where a higher input value should result in more output (e.g. opening a valve).

⚠️ Disclaimer:
This modification is not thoroughly tested, and is shared as an initial contribution to help or inspire further development.
If there's interest, I'm happy to refine or improve it based on feedback.

Thank you for your great work on this integration!