### PR TITLE
Fix the PID controller to follow the set sample time

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -152,7 +152,7 @@ async def test_update_pid_output_limits_none_when_windup_protection_disabled(
 
     # Dummy PID to inspect output_limits
     class DummyPID:
-        def __init__(self, kp, ki, kd, setpoint):
+        def __init__(self, kp, ki, kd, setpoint, sample_time=None):
             self._proportional = 1.0
             self._integral = 1.0
             self._last_output = None


### PR DESCRIPTION
We give out the intended sample time out to simple_pid, which uses it to filter out calls that happen too often.

However, we often call simple_pid a fraction of a second sooner than it expects, causing the entire PID loop iteration to be skipped.

In my test system this happens on almost every round, causing my 60-second PID controller to effectively only update every 120 seconds.

Since we already only call simple_pid every sample_time seconds, there is no need to keep the simple_pid's filtering check in place. The filtering check is the only thing simple_pid uses the sample_time value for, so we can simply omit giving out our sample_time to it.