### PR TITLE
Fix applying startup setting when starting in auto mode

### DIFF
--- a/custom_components/simple_pid_controller/sensor.py
+++ b/custom_components/simple_pid_controller/sensor.py
@@ -33,7 +33,6 @@ async def async_setup_entry(
 ) -> None:
     """Set up PID output and diagnostic sensors."""
     handle: PIDDeviceHandle = entry.runtime_data.handle
-    handle.init_phase = True
 
     # Init PID with default values
     handle.pid = PID(1.0, 0.1, 0.05, setpoint=50, sample_time=None, auto_mode=False)
@@ -72,10 +71,7 @@ async def async_setup_entry(
             handle.pid.output_limits = (None, None)
 
         _LOGGER.debug("Start mode = %s (type: %s)", start_mode, type(start_mode))
-        if (handle.init_phase and auto_mode) or (
-            not handle.pid.auto_mode and auto_mode
-        ):
-            handle.init_phase = False
+        if not handle.pid.auto_mode and auto_mode:
             if start_mode == "Zero start":
                 handle.pid.set_auto_mode(True, 0)
             elif start_mode == "Last known value":
@@ -86,7 +82,6 @@ async def async_setup_entry(
                 handle.pid.set_auto_mode(True)
         else:
             handle.pid.auto_mode = auto_mode
-            handle.init_phase = False
 
         handle.pid.proportional_on_measurement = p_on_m
 

--- a/custom_components/simple_pid_controller/sensor.py
+++ b/custom_components/simple_pid_controller/sensor.py
@@ -36,7 +36,7 @@ async def async_setup_entry(
     handle.init_phase = True
 
     # Init PID with default values
-    handle.pid = PID(1.0, 0.1, 0.05, setpoint=50, sample_time=None)
+    handle.pid = PID(1.0, 0.1, 0.05, setpoint=50, sample_time=None, auto_mode=False)
 
     handle.pid.output_limits = (-10.0, 10.0)
     handle.last_contributions = (0, 0, 0, 0)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -159,13 +159,13 @@ async def test_update_pid_output_limits_none_when_windup_protection_disabled(
 
     # Dummy PID class
     class DummyPID:
-        def __init__(self, kp=0, ki=0, kd=0, setpoint=0, sample_time=None):
+        def __init__(self, kp=0, ki=0, kd=0, setpoint=0, sample_time=None, auto_mode=True):
             self.Kp = kp
             self.Ki = ki
             self.Kd = kd
             self.setpoint = setpoint
             self.sample_time = sample_time
-            self.auto_mode = False
+            self.auto_mode = auto_mode
             self.proportional_on_measurement = False
             self.tunings = (kp, ki, kd)
             self.output_limits = (123, 456)  # dummy init waarde
@@ -269,13 +269,13 @@ async def test_update_pid_invalid_start_mode_defaults(monkeypatch, hass, config_
 
     # Dummy PID class matching existing tests
     class DummyPID:
-        def __init__(self, kp=0, ki=0, kd=0, setpoint=0, sample_time=None):
+        def __init__(self, kp=0, ki=0, kd=0, setpoint=0, sample_time=None, auto_mode=True):
             self.Kp = kp
             self.Ki = ki
             self.Kd = kd
             self.setpoint = setpoint
             self.sample_time = sample_time
-            self.auto_mode = False
+            self.auto_mode = auto_mode
             self.proportional_on_measurement = False
             self.tunings = (kp, ki, kd)
             self.output_limits = (123, 456)


### PR DESCRIPTION
simple-pid only applies the `set_auto_mode()` `last_output=` parameter
when going from manual mode to auto mode, and it starts up in auto mode
by default.

In case we also want to start in auto mode, we try to set the wanted
starting output via `set_auto_mode()` but that is ineffective.

Fix that by always starting the simple-pid in manual mode, and switch it
to auto mode during the first loop which causes the wanted startup value
to be actually set.

---

I had somehow missed this one when testing your test version, sorry about that.