### PR TITLE
Update README.md to reflect timer changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,29 +148,17 @@ A PID controller continuously corrects the difference between a **setpoint** and
 1. **Initialization**  
    - On startup (or when options change), we set up a single `sample_time` value (in seconds).  
    - We register a periodic callback with Home Assistant’s scheduler (`async_track_time_interval` or `DataUpdateCoordinator`) using that same `sample_time`.  
-   - We also configure the PID algorithm’s internal timer to the same `sample_time`.
 
 2. **Coordinator Tick**  
    - Every `sample_time` seconds, Home Assistant’s scheduler invokes our update method.  
    - We immediately read the current process variable (e.g. temperature sensor) and pass it to the PID logic.
 
 3. **PID Logic & Output**  
-   - The PID algorithm checks whether at least `sample_time` seconds have elapsed since its own last computation.  
-   - If so, it calculates the Proportional, Integral, and Derivative terms and writes the result to your target entity (e.g. a heater or set-point).  
-   - If not (because the PID’s internal timer hasn’t quite reached the next tick), it skips the computation until its own timer allows it.
+   - The PID algorithm calculates the Proportional, Integral, and Derivative terms and writes the result to your target entity (e.g. a heater or set-point).
 
-4. **Timer Drift & Overlap**  
-   - Both the coordinator and the PID controller schedule their next run relative to when the current one started. Under heavy load, one callback may run a few milliseconds later than expected.  
-   - Because each timer is independent, occasional “double-ticks” or small gaps can occur:  
-     - If the scheduler drifts early but the PID timer hasn’t yet reached `sample_time`, no computation runs.  
-     - If the PID timer elapses first and the scheduler callback is slightly late, the update happens immediately when the scheduler finally fires.  
-   - Over time, these small variances average out, preserving an approximately consistent interval.
-
-5. **Adjusting Sample Time**  
+4. **Adjusting Sample Time**
    - Changing `sample_time` in your integration options takes effect at the end of the current interval—no Home Assistant restart is required.  
-   - On the next tick, both the coordinator and the PID logic will use the new interval.
-
-By using a single **Sample Time** for both scheduling and calculation—and understanding that each component tracks its own clock—you get predictable, evenly-spaced control updates while allowing Home Assistant’s event loop to manage timing drifts gracefully.```
+   - On the next tick, the coordinator will use the new interval.
 
 ---
 


### PR DESCRIPTION
We are now relying on a single timer (the HA coordinator timer), so remove the descriptions of PID timer and timer drift.