### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bvweerd/simple_pid_controller/security/code-scanning/13](https://github.com/bvweerd/simple_pid_controller/security/code-scanning/13)

To fix the issue, add a `permissions` block to the workflow. Since the workflow requires write access to upload a release asset, the `contents` permission should be set to `read` (to access repository contents) and `contents: write` should be avoided unless absolutely necessary. Additionally, the `permissions` block should be added at the root level of the workflow to apply to all jobs unless overridden.

The updated workflow will explicitly define the required permissions, ensuring that the `GITHUB_TOKEN` has only the minimal privileges needed to complete the task.

---

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._