### PR TITLE
Share PID handle across all entities

### DIFF
--- a/custom_components/simple_pid_controller/entity.py
+++ b/custom_components/simple_pid_controller/entity.py
@@ -5,7 +5,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity, DeviceInfo
 
 from .const import DOMAIN
-from . import PIDDeviceHandle
 
 
 class BasePIDEntity(Entity):
@@ -21,7 +20,7 @@ class BasePIDEntity(Entity):
         """Initialize the base PID entity."""
         self.hass = hass
         self._entry = entry
-        self._handle = PIDDeviceHandle(hass, entry)
+        self._handle = entry.runtime_data.handle
         self._key = key
 
         # Common entity attributes

--- a/custom_components/simple_pid_controller/sensor.py
+++ b/custom_components/simple_pid_controller/sensor.py
@@ -204,16 +204,15 @@ class PIDOutputSensor(
 
         self._attr_native_unit_of_measurement = "%"
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self.handle = entry.runtime_data.handle
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
         if (state := await self.async_get_last_state()) is not None:
             try:
                 value = float(state.state)
-                self.handle.last_known_output = value
+                self._handle.last_known_output = value
             except (ValueError, TypeError):
-                self.handle.last_known_output = 0.0
+                self._handle.last_known_output = 0.0
 
     @property
     def native_value(self) -> float | None:
@@ -241,7 +240,6 @@ class PIDContributionSensor(CoordinatorEntity[PIDDataCoordinator], SensorEntity)
         self._attr_entity_registry_enabled_default = False
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._key = key
-        self._handle = entry.runtime_data.handle
 
     @property
     def native_value(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -76,7 +76,7 @@ async def test_pid_contribution_native_value_rounding_and_none(hass, config_entr
             f"sensor.{config_entry.entry_id}_{key}",
             coordinator,
         )
-        sensor._handle = handle  # inject mock handle
+        assert sensor._handle is handle
         assert sensor.native_value == expected
 
     # Unknown key should return None
@@ -87,7 +87,7 @@ async def test_pid_contribution_native_value_rounding_and_none(hass, config_entr
         "sensor.{config_entry.entry_id}_pid_x_contrib",
         coordinator,
     )
-    sensor_none._handle = handle
+    assert sensor_none._handle is handle
     assert sensor_none.native_value is None
 
 
@@ -350,7 +350,7 @@ def test_pid_contribution_error_when_input_or_setpoint_none(hass, config_entry):
     sensor = PIDContributionSensor(
         hass, config_entry, "error", "Error Sensor", coordinator
     )
-    sensor._handle = handle
+    assert sensor._handle is handle
     assert sensor.native_value == 0
 
     # Case 2: setpoint is None → error = 0
@@ -359,5 +359,5 @@ def test_pid_contribution_error_when_input_or_setpoint_none(hass, config_entry):
     sensor = PIDContributionSensor(
         hass, config_entry, "error", "Error Sensor", coordinator
     )
-    sensor._handle = handle
+    assert sensor._handle is handle
     assert sensor.native_value == 0


### PR DESCRIPTION
## Summary
- use `entry.runtime_data.handle` inside BasePIDEntity
- remove redundant handle assignments in sensors
- update tests to verify entities share the same handle

## Testing
- `pre-commit run --files custom_components/simple_pid_controller/entity.py custom_components/simple_pid_controller/sensor.py tests/test_sensor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac8c3a0a4832387e0de0833e4ce15