### PR TITLE
Ensure sensor listeners clean up

### DIFF
--- a/custom_components/simple_pid_controller/sensor.py
+++ b/custom_components/simple_pid_controller/sensor.py
@@ -172,19 +172,22 @@ async def async_setup_entry(
         "output_max",
         "sample_time",
     ]:
-        hass.bus.async_listen(
+        unsub = hass.bus.async_listen(
             "state_changed", make_listener(f"number.{entry.entry_id}_{key}")
         )
+        entry.async_on_unload(unsub)
 
     for key in ["auto_mode", "proportional_on_measurement", "windup_protection"]:
-        hass.bus.async_listen(
+        unsub = hass.bus.async_listen(
             "state_changed", make_listener(f"switch.{entry.entry_id}_{key}")
         )
+        entry.async_on_unload(unsub)
 
     for key in ["start_mode"]:
-        hass.bus.async_listen(
+        unsub = hass.bus.async_listen(
             "state_changed", make_listener(f"select.{entry.entry_id}_{key}")
         )
+        entry.async_on_unload(unsub)
 
 
 class PIDOutputSensor(

--- a/tests/test_unload_listeners.py
+++ b/tests/test_unload_listeners.py
@@ -1,0 +1,33 @@
+import pytest
+
+from custom_components.simple_pid_controller.sensor import async_setup_entry
+
+
+@pytest.fixture(autouse=True)
+async def skip_setup_integration():
+    """Override autouse setup from conftest; tests will setup manually."""
+    yield
+
+
+@pytest.mark.asyncio
+async def test_listeners_removed_after_unload(hass, config_entry, monkeypatch):
+    """Ensure state change listeners are unsubscribed when the entry unloads."""
+    created = []
+    called = []
+
+    def fake_listen(self, event, callback):
+        def unsub():
+            called.append(True)
+        created.append(unsub)
+        return unsub
+
+    monkeypatch.setattr(type(hass.bus), "async_listen", fake_listen)
+
+    await async_setup_entry(hass, config_entry, lambda e: None)
+
+    # Expect listeners created for all parameters
+    assert len(created) > 0
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+    assert len(called) == len(created)


### PR DESCRIPTION
## Summary
- hook state change listeners using entry.async_on_unload
- remove local pytest stubs and rely on real plugin
- test that listeners unsubscribe after config entry unload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac96844008323b16c8940996613eb