### PR TITLE
Cooling Mode

### DIFF
--- a/custom_components/simple_pid_controller/sensor.py
+++ b/custom_components/simple_pid_controller/sensor.py
@@ -60,6 +60,7 @@ async def async_setup_entry(
         auto_mode = handle.get_switch("auto_mode")
         p_on_m = handle.get_switch("proportional_on_measurement")
         windup_protection = handle.get_switch("windup_protection")
+        cooling_mode = handle.get_switch("cooling_mode")
 
         # adapt PID settings
         handle.pid.tunings = (kp, ki, kd)
@@ -86,6 +87,8 @@ async def async_setup_entry(
         handle.pid.proportional_on_measurement = p_on_m
 
         output = handle.pid(input_value)
+        if cooling_mode:
+            output = out_max + out_min - output
 
         # save last know output
         handle.last_known_output = output

--- a/custom_components/simple_pid_controller/switch.py
+++ b/custom_components/simple_pid_controller/switch.py
@@ -24,6 +24,11 @@ SWITCH_ENTITIES = [
         "name": "Windup Protection",
         "default_state": True,
     },
+    {
+        "key": "cooling_mode",
+        "name": "Cooling Mode",
+        "default_state": True,
+    },
 ]
 
 


### PR DESCRIPTION
## 📝 What’s Changed?

- Forked the original Simple PID Controller integration to create **Simple PID Heater/Cooler Controller**.
- Added support for controlling both heating and cooling modes with an option to toggle mode.
- Updated configuration flow and options to include output inversion logic for cooling.
- Adjusted documentation to reflect new functionality and usage.

## 🔍 Why is this Change Needed?

- The original integration only supported PID control for heating devices.
- Many use cases require controlling cooling devices or systems that can both heat and cool.
- This modification allows Home Assistant users to manage temperature regulation more flexibly using a single integration.

## 🧪 How Was This Tested?

- [ ] Added or updated unit tests
- [x] Manually tested in development environment
- [ ] CI/CD pipeline passed successfully