### PR TITLE
Add relay autotuner switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - **Diagnostics** for P, I, and D terms (optional).
 - **Switch** to toggle auto mode and proportional-on-measurement.
 - **Configurable** output limits, setpoint, and sample time.
+- **Autotuner** based on the relay method for automatic gain estimation with a dedicated switch to trigger tuning.
 
 ### Included Entities
 
@@ -45,6 +46,7 @@
 | Switch   | `Auto Mode`               | Toggle automatic control                |
 | Switch   | `Proportional on Measurement` | Change proportional mode         |
 | Switch   | `Windup Protection`       | Toggle windup protection                |
+| Switch   | `Autotune`                | Start relay-based autotuning            |
 
 
 > 💡 All entities are editable via the UI in **Settings > Devices & Services > [Your Controller] > Options**.
@@ -104,6 +106,7 @@ The controller’s setpoint range defaults to **0.0 – 100.0**. To customize th
 | Switch   | `Auto Mode`                   | Enable/disable PID automation.                     |
 | Switch   | `Proportional on Measurement` | Use measurement instead of error for P term.       |
 | Switch   | `Windup Protection`           | Toggle windup protection                           |
+| Switch   | `Autotune`                    | Trigger relay autotuning of PID gains              |
 
 ---
 

--- a/custom_components/simple_pid_controller/autotune.py
+++ b/custom_components/simple_pid_controller/autotune.py
@@ -1,0 +1,62 @@
+"""Relay based auto-tuning for PID parameters."""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+
+class RelayAutoTuner:
+    """Perform PID autotuning using the relay (Åström–Hägglund) method.
+
+    The implementation analyses oscillations obtained by exciting the
+    process with a relay (on/off) controller.  From the sustained
+    oscillations the ultimate gain and period are derived and translated
+    to PID parameters using the classic Ziegler–Nichols rules.
+    """
+
+    @staticmethod
+    def tune(
+        data: Sequence[float],
+        sample_time: float,
+        relay_amplitude: float,
+    ) -> tuple[float, float, float]:
+        """Return ``(kp, ki, kd)`` for the given oscillation data.
+
+        ``data`` should contain process values around the setpoint for at
+        least two complete oscillation cycles. ``sample_time`` is the time
+        between data points in seconds. ``relay_amplitude`` is the output
+        step (absolute value) used during the relay test.
+        """
+
+        if len(data) < 3:
+            raise ValueError("Not enough data for autotune")
+
+        maxima: list[tuple[int, float]] = []
+        minima: list[tuple[int, float]] = []
+        for i in range(1, len(data) - 1):
+            prev_, cur, next_ = data[i - 1], data[i], data[i + 1]
+            if cur > prev_ and cur > next_:
+                maxima.append((i, cur))
+            if cur < prev_ and cur < next_:
+                minima.append((i, cur))
+
+        # Need at least two maxima and one minima to determine amplitude and period
+        if len(maxima) < 2 or len(minima) < 1:
+            raise ValueError("Could not determine oscillation characteristics")
+
+        # Determine oscillation period using last two maxima
+        last_idx, prev_idx = maxima[-1][0], maxima[-2][0]
+        pu = (last_idx - prev_idx) * sample_time
+
+        max_avg = sum(v for _, v in maxima) / len(maxima)
+        min_avg = sum(v for _, v in minima) / len(minima)
+        a = (max_avg - min_avg) / 2.0
+        if a <= 0:
+            raise ValueError("Invalid oscillation amplitude")
+
+        ku = 4.0 * relay_amplitude / (math.pi * a)
+        kp = 0.6 * ku
+        ki = 1.2 * ku / pu
+        kd = 0.075 * ku * pu
+        return kp, ki, kd

--- a/custom_components/simple_pid_controller/switch.py
+++ b/custom_components/simple_pid_controller/switch.py
@@ -24,6 +24,11 @@ SWITCH_ENTITIES = [
         "name": "Windup Protection",
         "default_state": True,
     },
+    {
+        "key": "autotune",
+        "name": "Autotune",
+        "default_state": False,
+    },
 ]
 
 

--- a/tests/test_autotune.py
+++ b/tests/test_autotune.py
@@ -50,7 +50,9 @@ async def test_autotune_switch_sets_gains_and_turns_off(
 
     # Turn on autotune switch
     entity_id = f"switch.{config_entry.entry_id}_autotune"
-    await hass.services.async_call("switch", "turn_on", {"entity_id": entity_id}, blocking=True)
+    await hass.services.async_call(
+        "switch", "turn_on", {"entity_id": entity_id}, blocking=True
+    )
 
     coordinator = config_entry.runtime_data.coordinator
     await coordinator.update_method()

--- a/tests/test_autotune.py
+++ b/tests/test_autotune.py
@@ -1,0 +1,61 @@
+import math
+
+import pytest
+
+from custom_components.simple_pid_controller.autotune import RelayAutoTuner
+
+
+def test_relay_autotuner_sine_wave():
+    """Relay autotuner computes correct gains from sine oscillation."""
+    sample_time = 0.05
+    relay_amplitude = 1.5
+    period = 5.0  # seconds
+    amplitude = 2.0
+
+    steps = int(period * 5 / sample_time)  # five periods
+    data = [
+        amplitude * math.sin(2 * math.pi * i * sample_time / period)
+        for i in range(steps)
+    ]
+
+    kp, ki, kd = RelayAutoTuner.tune(data, sample_time, relay_amplitude)
+
+    ku = 4 * relay_amplitude / (math.pi * amplitude)
+    assert kp == pytest.approx(0.6 * ku, rel=2e-2)
+    assert ki == pytest.approx(1.2 * ku / period, rel=2e-2)
+    assert kd == pytest.approx(0.075 * ku * period, rel=2e-2)
+
+
+@pytest.mark.asyncio
+async def test_autotune_switch_sets_gains_and_turns_off(
+    hass, config_entry, monkeypatch
+):
+    """Turning on the autotune switch should populate gains and switch off."""
+
+    # Patch autotuner to return deterministic values immediately
+    def fake_tune(data, sample_time, relay):
+        return (2.0, 3.0, 4.0)
+
+    monkeypatch.setattr(RelayAutoTuner, "tune", staticmethod(fake_tune))
+
+    handle = config_entry.runtime_data.handle
+    handle.get_input_sensor_value = lambda: 1.0
+    handle.get_number = lambda key: {
+        "sample_time": 1.0,
+        "output_min": 0.0,
+        "output_max": 10.0,
+        "setpoint": 0.0,
+        "starting_output": 0.0,
+    }[key]
+
+    # Turn on autotune switch
+    entity_id = f"switch.{config_entry.entry_id}_autotune"
+    await hass.services.async_call("switch", "turn_on", {"entity_id": entity_id}, blocking=True)
+
+    coordinator = config_entry.runtime_data.coordinator
+    await coordinator.update_method()
+
+    assert hass.states.get(entity_id).state == "off"
+    assert hass.states.get(f"number.{config_entry.entry_id}_kp").state == "2.0"
+    assert hass.states.get(f"number.{config_entry.entry_id}_ki").state == "3.0"
+    assert hass.states.get(f"number.{config_entry.entry_id}_kd").state == "4.0"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -36,8 +36,8 @@ async def test_pid_start_modes(hass, config_entry):
             "output_min": 0.0,
             "output_max": 100.0,
         }[key]
-        handle.get_switch = (
-            lambda key, default=True: False if key == "autotune" else True
+        handle.get_switch = lambda key, default=True: (
+            False if key == "autotune" else True
         )
 
         # trigger initial update

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -36,7 +36,9 @@ async def test_pid_start_modes(hass, config_entry):
             "output_min": 0.0,
             "output_max": 100.0,
         }[key]
-        handle.get_switch = lambda key: True
+        handle.get_switch = (
+            lambda key, default=True: False if key == "autotune" else True
+        )
 
         # trigger initial update
         hass.bus.async_fire("homeassistant_started")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -32,7 +32,9 @@ async def test_pid_output_and_contributions_update(hass, config_entry):
         "output_min": 0.0,
         "output_max": 100.0,
     }[key]
-    handle.get_switch = lambda key: True
+    handle.get_switch = (
+        lambda key, default=True: False if key == "autotune" else True
+    )
 
     # 1) trigger initial update
     hass.bus.async_fire("homeassistant_started")
@@ -98,7 +100,9 @@ async def test_listeners_trigger_refresh_sensor(hass, config_entry, monkeypatch)
     handle = config_entry.runtime_data.handle
     handle.get_input_sensor_value = lambda: 0.0
     handle.get_number = lambda key: 0.0
-    handle.get_switch = lambda key: True
+    handle.get_switch = (
+        lambda key, default=True: False if key == "autotune" else True
+    )
 
     # Capture listeners
     listeners = []
@@ -141,7 +145,9 @@ async def test_update_pid_raises_on_missing_input(hass, config_entry):
     handle.get_input_sensor_value = lambda: None
     # Provide defaults for numbers and switches
     handle.get_number = lambda key: 0.0
-    handle.get_switch = lambda key: True
+    handle.get_switch = (
+        lambda key, default=True: False if key == "autotune" else True
+    )
     # Setup entry to get coordinator with update_method
     entities: list = []
     await async_setup_entry(hass, config_entry, lambda e: entities.extend(e))
@@ -202,7 +208,11 @@ async def test_update_pid_output_limits_none_when_windup_protection_disabled(
         "output_min": 0.0,
         "output_max": 100.0,
     }.get(key, 0.0)
-    handle.get_switch = lambda key: False if key == "windup_protection" else True
+    handle.get_switch = (
+        lambda key, default=True: False
+        if key in ("windup_protection", "autotune")
+        else True
+    )
     handle.get_select = lambda key: "Zero start" if key == "start_mode" else None
 
     # Set-up components and trigger update
@@ -312,7 +322,9 @@ async def test_update_pid_invalid_start_mode_defaults(monkeypatch, hass, config_
         "output_min": 0.0,
         "output_max": 100.0,
     }[key]
-    handle.get_switch = lambda key: True
+    handle.get_switch = (
+        lambda key, default=True: False if key == "autotune" else True
+    )
     handle.get_select = lambda key: "Invalid Mode" if key == "start_mode" else None
 
     # Run setup and trigger one PID update
@@ -385,7 +397,9 @@ async def test_update_pid_adjusts_update_interval(hass, config_entry, monkeypatc
         "output_min": 0.0,
         "output_max": 100.0,
     }[key]
-    handle.get_switch = lambda key: True
+    handle.get_switch = (
+        lambda key, default=True: False if key == "autotune" else True
+    )
 
     entities = []
     await async_setup_entry(hass, config_entry, lambda e: entities.extend(e))

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -32,9 +32,7 @@ async def test_pid_output_and_contributions_update(hass, config_entry):
         "output_min": 0.0,
         "output_max": 100.0,
     }[key]
-    handle.get_switch = (
-        lambda key, default=True: False if key == "autotune" else True
-    )
+    handle.get_switch = lambda key, default=True: False if key == "autotune" else True
 
     # 1) trigger initial update
     hass.bus.async_fire("homeassistant_started")
@@ -100,9 +98,7 @@ async def test_listeners_trigger_refresh_sensor(hass, config_entry, monkeypatch)
     handle = config_entry.runtime_data.handle
     handle.get_input_sensor_value = lambda: 0.0
     handle.get_number = lambda key: 0.0
-    handle.get_switch = (
-        lambda key, default=True: False if key == "autotune" else True
-    )
+    handle.get_switch = lambda key, default=True: False if key == "autotune" else True
 
     # Capture listeners
     listeners = []
@@ -145,9 +141,7 @@ async def test_update_pid_raises_on_missing_input(hass, config_entry):
     handle.get_input_sensor_value = lambda: None
     # Provide defaults for numbers and switches
     handle.get_number = lambda key: 0.0
-    handle.get_switch = (
-        lambda key, default=True: False if key == "autotune" else True
-    )
+    handle.get_switch = lambda key, default=True: False if key == "autotune" else True
     # Setup entry to get coordinator with update_method
     entities: list = []
     await async_setup_entry(hass, config_entry, lambda e: entities.extend(e))
@@ -208,10 +202,8 @@ async def test_update_pid_output_limits_none_when_windup_protection_disabled(
         "output_min": 0.0,
         "output_max": 100.0,
     }.get(key, 0.0)
-    handle.get_switch = (
-        lambda key, default=True: False
-        if key in ("windup_protection", "autotune")
-        else True
+    handle.get_switch = lambda key, default=True: (
+        False if key in ("windup_protection", "autotune") else True
     )
     handle.get_select = lambda key: "Zero start" if key == "start_mode" else None
 
@@ -322,9 +314,7 @@ async def test_update_pid_invalid_start_mode_defaults(monkeypatch, hass, config_
         "output_min": 0.0,
         "output_max": 100.0,
     }[key]
-    handle.get_switch = (
-        lambda key, default=True: False if key == "autotune" else True
-    )
+    handle.get_switch = lambda key, default=True: False if key == "autotune" else True
     handle.get_select = lambda key: "Invalid Mode" if key == "start_mode" else None
 
     # Run setup and trigger one PID update
@@ -397,9 +387,7 @@ async def test_update_pid_adjusts_update_interval(hass, config_entry, monkeypatc
         "output_min": 0.0,
         "output_max": 100.0,
     }[key]
-    handle.get_switch = (
-        lambda key, default=True: False if key == "autotune" else True
-    )
+    handle.get_switch = lambda key, default=True: False if key == "autotune" else True
 
     entities = []
     await async_setup_entry(hass, config_entry, lambda e: entities.extend(e))


### PR DESCRIPTION
## Summary
- add `autotune` switch to trigger relay-based PID tuning
- write tuned gains to number entities and switch off when complete
- document autotune switch and cover with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893105417c88323bb9c71bf37d93878