### PR TITLE
refactor tests integration setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def _enable_custom_integrations(enable_custom_integrations):
     """Enable loading of custom integrations in custom_components/"""  # noqa: F811
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 async def setup_integration(hass, config_entry):
     """Set up the integration automatically for each test."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,3 +1,4 @@
+import pytest
 from custom_components.simple_pid_controller.diagnostics import (
     async_get_config_entry_diagnostics,
 )
@@ -12,6 +13,7 @@ from custom_components.simple_pid_controller.const import (
 )
 
 
+@pytest.mark.usefixtures("setup_integration")
 async def test_config_entry_diagnostics(hass, config_entry):
     """Test that diagnostics returns correct data for config entry."""
     result = await async_get_config_entry_diagnostics(hass, config_entry)

--- a/tests/test_init_unload.py
+++ b/tests/test_init_unload.py
@@ -15,12 +15,7 @@ from custom_components.simple_pid_controller.const import (
 )
 
 
-@pytest.fixture
-async def skip_setup_integration():
-    """Override autouse setup so tests can call setup manually."""
-    yield
-
-
+@pytest.mark.usefixtures("setup_integration")
 async def test_setup_and_unload_entry(hass, config_entry):
     """Test setting up and tearing down the entry."""
     # runtime_data should exist…
@@ -49,7 +44,6 @@ async def test_setup_and_unload_entry(hass, config_entry):
     assert DOMAIN not in hass.data
 
 
-@pytest.mark.usefixtures("skip_setup_integration")
 @pytest.mark.asyncio
 async def test_setup_entry_not_ready_when_sensor_missing(hass, caplog):
     """async_setup_entry should raise when the sensor state is missing."""

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -14,6 +14,7 @@ from custom_components.simple_pid_controller.const import (
 )
 
 
+@pytest.mark.usefixtures("setup_integration")
 async def test_number_platform(hass, config_entry):
     """Check that all Number entities from PID_NUMBER_ENTITIES are created."""
 
@@ -21,6 +22,7 @@ async def test_number_platform(hass, config_entry):
     assert len(numbers) == len(PID_NUMBER_ENTITIES) + len(CONTROL_NUMBER_ENTITIES)
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.parametrize("desc", PID_NUMBER_ENTITIES)
 async def test_number_entity_attributes(hass, config_entry, desc):
     entity_id = f"number.{config_entry.entry_id}_{desc['key']}"
@@ -42,6 +44,7 @@ async def test_number_entity_attributes(hass, config_entry, desc):
     # assert state.name == desc.get("name", state.name)
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.parametrize(
     "last_value, expected",
     [
@@ -69,6 +72,7 @@ async def test_async_added_to_hass_clamps_pid_value(
     assert num.native_value == expected
 
 
+@pytest.mark.usefixtures("setup_integration")
 async def test_async_added_to_hass_clamps_control_value(
     hass, config_entry, monkeypatch
 ):
@@ -105,6 +109,7 @@ async def test_async_added_to_hass_clamps_control_value(
         assert num.native_value == mid
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.parametrize(
     "clazz, desc, sample_value",
     [
@@ -133,6 +138,7 @@ async def test_async_set_native_value_triggers_write(
     assert write_calls, "async_write_ha_state was not called"
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.parametrize(
     "invalid_key, expected_min, expected_max",
     [

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -8,6 +8,7 @@ from custom_components.simple_pid_controller.select import (
 )
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_pid_start_modes(hass, config_entry):
     """Check start modes."""
@@ -61,6 +62,7 @@ async def test_pid_start_modes(hass, config_entry):
     )
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_async_select_option_applies_only_valid_options(
     hass, config_entry, monkeypatch
@@ -96,6 +98,7 @@ async def test_async_select_option_applies_only_valid_options(
     ), "async_write_ha_state should not be called for an invalid option"
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "last_state, expected_option",
@@ -132,6 +135,7 @@ async def test_async_added_to_hass_restores_previous_state(
     assert select._attr_current_option == expected_option
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_async_added_to_hass_invalid_last_state(hass, config_entry, monkeypatch):
     """Ensure invalid last state does not override default option."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -11,6 +11,7 @@ from custom_components.simple_pid_controller.sensor import async_setup_entry
 from custom_components.simple_pid_controller import sensor as sensor_module
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_pid_output_and_contributions_update(hass, config_entry):
     """Test that PID output and contribution sensors update on Home Assistant start."""
@@ -50,6 +51,7 @@ async def test_pid_output_and_contributions_update(hass, config_entry):
     assert float(state.state) != 0
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_pid_contribution_native_value_rounding_and_none(hass, config_entry):
     """Test that PIDContributionSensor.native_value rounds correctly and returns None for unknown key."""
@@ -91,6 +93,7 @@ async def test_pid_contribution_native_value_rounding_and_none(hass, config_entr
     assert sensor_none.native_value is None
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_listeners_trigger_refresh_sensor(hass, config_entry, monkeypatch):
     """Lines 131-132: coordinator.async_request_refresh called on sensor state change."""
@@ -133,6 +136,7 @@ async def test_listeners_trigger_refresh_sensor(hass, config_entry, monkeypatch)
     ), "Coordinator.async_request_refresh was not called on sensor state change"
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_update_pid_raises_on_missing_input(hass, config_entry):
     """Line 47: update_pid should raise ValueError when input sensor unavailable."""
@@ -151,6 +155,7 @@ async def test_update_pid_raises_on_missing_input(hass, config_entry):
     assert "Input sensor not available" in str(excinfo.value)
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_update_pid_output_limits_none_when_windup_protection_disabled(
     monkeypatch, hass, config_entry
@@ -225,6 +230,7 @@ async def test_update_pid_output_limits_none_when_windup_protection_disabled(
     assert pid.output_limits == (None, None)
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "restored_state, expected_last_known",
@@ -265,6 +271,7 @@ async def test_async_added_to_hass_restores_last_known_output(
     assert handle.last_known_output == expected_last_known
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_update_pid_invalid_start_mode_defaults(monkeypatch, hass, config_entry):
     """Line 86: invalid start_mode calls set_auto_mode(True) without changing output."""
@@ -338,6 +345,7 @@ async def test_update_pid_invalid_start_mode_defaults(monkeypatch, hass, config_
     assert pid._output == 42.0
 
 
+@pytest.mark.usefixtures("setup_integration")
 def test_pid_contribution_error_when_input_or_setpoint_none(hass, config_entry):
     """Line 258: native_value for 'error' should be 0 when input or setpoint is None."""
     handle = config_entry.runtime_data.handle
@@ -363,6 +371,7 @@ def test_pid_contribution_error_when_input_or_setpoint_none(hass, config_entry):
     assert sensor.native_value == 0
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_update_pid_adjusts_update_interval(hass, config_entry, monkeypatch):
     """Ensure coordinator.update_interval updates when sample_time changes."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5,6 +5,7 @@ from custom_components.simple_pid_controller.switch import (
 )
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_switch_operations(hass, config_entry):
     """Test that each switch entity is created and can be toggled on/off."""
@@ -34,6 +35,7 @@ async def test_switch_operations(hass, config_entry):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("last_state, expected", [("on", True), ("off", False)])
+@pytest.mark.usefixtures("setup_integration")
 async def test_async_added_to_hass_restores_previous_state(
     hass, config_entry, monkeypatch, last_state, expected
 ):

--- a/tests/test_unload_listeners.py
+++ b/tests/test_unload_listeners.py
@@ -3,12 +3,7 @@ import pytest
 from custom_components.simple_pid_controller.sensor import async_setup_entry
 
 
-@pytest.fixture(autouse=True)
-async def skip_setup_integration():
-    """Override autouse setup from conftest; tests will setup manually."""
-    yield
-
-
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
 async def test_listeners_removed_after_unload(hass, config_entry, monkeypatch):
     """Ensure state change listeners are unsubscribed when the entry unloads."""

--- a/tests/test_update_options_listener.py
+++ b/tests/test_update_options_listener.py
@@ -5,12 +5,6 @@ from custom_components.simple_pid_controller.const import DOMAIN
 from custom_components.simple_pid_controller import _async_update_options_listener
 
 
-@pytest.fixture(autouse=True)
-async def skip_setup_integration():
-    """Override autouse setup from conftest."""
-    yield
-
-
 @pytest.mark.asyncio
 async def test_async_update_options_listener_reload_called_once(hass, monkeypatch):
     entry = MockConfigEntry(domain=DOMAIN, entry_id="test_entry", data={})


### PR DESCRIPTION
## Summary
- stop automatically setting up Simple PID Controller integration in tests
- mark tests that require the full integration to use `setup_integration`
- drop unused `skip_setup_integration` fixtures

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a7d1477648323978a8851592f4e14