### PR TITLE
fix: specify issue labeler action version

### DIFF
--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: github/issue-labeler@v3
+      - uses: github/issue-labeler@v3.4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml


### PR DESCRIPTION
## Summary
- fix github issue labeler workflow by pinning to v3.4

## Testing
- `pre-commit run --files .github/workflows/label-issues.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cc25c0f6c832390aedede283e70eb