### PR TITLE
Add service to reset PID output

### DIFF
--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, config_validation as cv
 from dataclasses import dataclass
+import voluptuous as vol
 from .coordinator import PIDDataCoordinator
+from .select import START_MODE_OPTIONS
 
 from .const import (
     DOMAIN,
@@ -33,6 +35,8 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.SELECT,
 ]
+
+SERVICE_SET_OUTPUT = "set_output"
 
 
 @dataclass
@@ -149,6 +153,59 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(entry.add_update_listener(_async_update_options_listener))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    if not hass.services.has_service(DOMAIN, SERVICE_SET_OUTPUT):
+
+        async def async_set_output(call: ServiceCall) -> None:
+            entity_id = call.data["entity_id"]
+            start_mode = call.data.get("start_mode")
+            value = call.data.get("value")
+
+            registry = er.async_get(hass)
+            entity_entry = registry.async_get(entity_id)
+            if entity_entry is None:
+                raise ValueError(f"Entity {entity_id} not found")
+
+            cfg_entry = hass.config_entries.async_get_entry(
+                entity_entry.config_entry_id
+            )
+            if cfg_entry is None or cfg_entry.domain != DOMAIN:
+                raise ValueError(f"Entity {entity_id} does not belong to {DOMAIN}")
+
+            handle = cfg_entry.runtime_data.handle
+            coordinator = cfg_entry.runtime_data.coordinator
+
+            if start_mode == "Zero start":
+                output = 0.0
+            elif start_mode == "Last known value":
+                output = handle.last_known_output or 0.0
+            elif start_mode == "Startup value":
+                output = handle.get_number("starting_output") or 0.0
+            else:
+                output = value
+
+            handle.pid.reset()
+            handle.pid.set_auto_mode(True, output)
+            handle.last_known_output = output
+            if coordinator:
+                coordinator.async_set_updated_data(output)
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_OUTPUT,
+            async_set_output,
+            schema=vol.All(
+                vol.Schema(
+                    {
+                        vol.Required("entity_id"): cv.entity_id,
+                        vol.Optional("start_mode"): vol.In(START_MODE_OPTIONS),
+                        vol.Optional("value"): vol.Coerce(float),
+                    }
+                ),
+                cv.has_at_least_one_key("start_mode", "value"),
+            ),
+        )
+
     return True
 
 
@@ -157,6 +214,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         # reset runtime_data zodat tests slagen
         entry.runtime_data = None
+        if not hass.config_entries.async_entries(DOMAIN):
+            hass.services.async_remove(DOMAIN, SERVICE_SET_OUTPUT)
     return unload_ok
 
 

--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -1,0 +1,24 @@
+set_output:
+  name: Set PID output
+  description: Reset the PID controller and set its output to the selected value.
+  fields:
+    entity_id:
+      description: PID output sensor entity id.
+      example: sensor.pid2_pid_output
+    start_mode:
+      description: Use one of the predefined start modes.
+      example: Zero start
+      selector:
+        select:
+          options:
+            - Zero start
+            - Last known value
+            - Startup value
+    value:
+      description: Custom output value to apply when no start_mode is provided.
+      example: 10
+      selector:
+        number:
+          min: -100
+          max: 100
+          step: 1

--- a/tests/test_service_set_output.py
+++ b/tests/test_service_set_output.py
@@ -1,0 +1,43 @@
+import pytest
+
+from custom_components.simple_pid_controller import DOMAIN, SERVICE_SET_OUTPUT
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
+async def test_set_output_start_mode(hass, config_entry):
+    """Service sets output based on start mode."""
+    entity_id = f"sensor.{config_entry.entry_id}_pid_output"
+    handle = config_entry.runtime_data.handle
+    handle.get_number = lambda key: {"starting_output": 42.0}.get(key)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_OUTPUT,
+        {"entity_id": entity_id, "start_mode": "Startup value"},
+        blocking=True,
+    )
+
+    assert handle.last_known_output == 42.0
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert float(state.state) == 42.0
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
+async def test_set_output_custom_value(hass, config_entry):
+    """Service sets output to provided custom value."""
+    entity_id = f"sensor.{config_entry.entry_id}_pid_output"
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_OUTPUT,
+        {"entity_id": entity_id, "value": 7.5},
+        blocking=True,
+    )
+
+    handle = config_entry.runtime_data.handle
+    assert handle.last_known_output == 7.5
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert float(state.state) == 7.5


### PR DESCRIPTION
## Summary
- add `set_output` service to reset PID and set its output
- document service for UI usage
- test service for start modes and custom values

## Testing
- `pre-commit run --files custom_components/simple_pid_controller/__init__.py custom_components/simple_pid_controller/services.yaml tests/test_service_set_output.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cca7e5d6c8323a6b9a52b0f209a92