### PR TITLE
Add service to reset PID output

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,34 @@ Here's an example output showing the controller responding to a setpoint:
 
 ---
 
-## 🔧 Service Actions 
-This Integration does **not** expose any custom services. All interactions are performed via UI-based entities.
+## 🔧 Service Actions
 
+### `simple_pid_controller.set_output`
+
+Reset the PID controller and force its output to a specific value.
+
+Parameters:
+- **entity_id** – PID output sensor to control.
+- **start_mode** – optional; one of `Zero start`, `Last known value`, or `Startup value`.
+- **value** – optional; custom numeric output (-100 to 100) used when no start mode is selected.
+
+Either `start_mode` or `value` must be provided.
+
+This service can be called from Developer Tools → Services or from automations. Examples:
+
+```yaml
+service: simple_pid_controller.set_output
+target:
+  entity_id: sensor.heater_pid_output
+data:
+  start_mode: "Last known value"
+```
+
+```yaml
+service: simple_pid_controller.set_output
+target:
+  entity_id: sensor.heater_pid_output
+data:
+  value: 25
+```
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Reset the PID controller and force its output to a specific value.
 Parameters:
 - **entity_id** – PID output sensor to control.
 - **start_mode** – optional; one of `Zero start`, `Last known value`, or `Startup value`.
-- **value** – optional; custom numeric output (-100 to 100) used when no start mode is selected.
+- **value** – optional; custom numeric output used when no start mode is selected. The value must fall within the current Output Min and Output Max range (default 0–100).
 
 Either `start_mode` or `value` must be provided.
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Parameters:
 - **start_mode** – optional; one of `Zero start`, `Last known value`, or `Startup value`.
 - **value** – optional; custom numeric output used when no start mode is selected. The value must fall within the current Output Min and Output Max range (default 0–100).
 
-Either `start_mode` or `value` must be provided.
+Exactly one of `start_mode` or `value` must be provided.
 
 This service can be called from Developer Tools → Services or from automations. Examples:
 

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -157,7 +157,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not hass.services.has_service(DOMAIN, SERVICE_SET_OUTPUT):
 
         async def async_set_output(call: ServiceCall) -> None:
-            entity_id = call.data[ATTR_ENTITY_ID]
+            entity_id = call.data[ATTR_ENTITY_ID][0]
             start_mode = call.data.get("start_mode")
             value = call.data.get("value")
 
@@ -197,7 +197,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             schema=vol.All(
                 vol.Schema(
                     {
-                        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+                        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
                         vol.Optional("start_mode"): vol.In(START_MODE_OPTIONS),
                         vol.Optional("value"): vol.Coerce(float),
                     }

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -212,8 +212,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 vol.Schema(
                     {
                         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-                        vol.Optional("start_mode"): vol.In(START_MODE_OPTIONS),
-                        vol.Optional("value"): vol.Coerce(float),
+                        vol.Exclusive("start_mode", "set_output"): vol.In(
+                            START_MODE_OPTIONS
+                        ),
+                        vol.Exclusive("value", "set_output"): vol.Coerce(float),
                     }
                 ),
                 cv.has_at_least_one_key("start_mode", "value"),

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -182,6 +182,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             elif start_mode == "Startup value":
                 output = handle.get_number("starting_output") or 0.0
             else:
+                out_min = handle.get_number("output_min") or handle.output_range_min
+                out_max = handle.get_number("output_max") or handle.output_range_max
+                if value is None:
+                    raise vol.Invalid("Value must be provided when no start_mode is set")
+                if value < out_min or value > out_max:
+                    raise vol.Invalid(
+                        f"value {value} outside output range [{out_min}, {out_max}]"
+                    )
                 output = value
 
             handle.pid.reset()

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -185,7 +185,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 out_min = handle.get_number("output_min") or handle.output_range_min
                 out_max = handle.get_number("output_max") or handle.output_range_max
                 if value is None:
-                    raise vol.Invalid("Value must be provided when no start_mode is set")
+                    raise vol.Invalid(
+                        "Value must be provided when no start_mode is set"
+                    )
                 if value < out_min or value > out_max:
                     raise vol.Invalid(
                         f"value {value} outside output range [{out_min}, {out_max}]"

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -182,8 +182,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             elif start_mode == "Startup value":
                 output = handle.get_number("starting_output") or 0.0
             else:
-                out_min = handle.get_number("output_min") or handle.output_range_min
-                out_max = handle.get_number("output_max") or handle.output_range_max
+                out_min = handle.get_number("output_min")
+                if out_min is None:
+                    out_min = handle.output_range_min
+                out_max = handle.get_number("output_max")
+                if out_max is None:
+                    out_max = handle.output_range_max
                 if value is None:
                     raise vol.Invalid(
                         "Value must be provided when no start_mode is set"

--- a/custom_components/simple_pid_controller/sensor.py
+++ b/custom_components/simple_pid_controller/sensor.py
@@ -37,7 +37,10 @@ async def async_setup_entry(
     # Init PID with default values
     handle.pid = PID(1.0, 0.1, 0.05, setpoint=50, sample_time=None, auto_mode=False)
 
-    handle.pid.output_limits = (-10.0, 10.0)
+    handle.pid.output_limits = (
+        handle.output_range_min,
+        handle.output_range_max,
+    )
     handle.last_contributions = (0, 0, 0, 0)
     handle.last_known_output = None
 

--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -18,8 +18,17 @@ set_output:
             - Startup value
     value:
       name: Value
-      description: Custom output value to apply when no start_mode is provided.
+      description: Custom output value to apply when no start mode is provided.
       example: 10
       selector:
         number:
           mode: box
+  oneOf:
+    - name: Start mode
+      description: Use one of the predefined start modes.
+      required:
+        - start_mode
+    - name: Custom value
+      description: Custom output value to apply when no start mode is selected.
+      required:
+        - value

--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -5,21 +5,27 @@ set_output:
     entity:
       integration: simple_pid_controller
       domain: sensor
-  fields:
-    start_mode:
-      name: Start mode
+  oneOf:
+    - name: Start mode
       description: Use one of the predefined start modes.
-      example: Zero start
-      selector:
-        select:
-          options:
-            - Zero start
-            - Last known value
-            - Startup value
-    value:
-      name: Value
-      description: Custom output value to apply when no start_mode is provided.
-      example: 10
-      selector:
-        number:
-          mode: box
+      fields:
+        start_mode:
+          name: Start mode
+          description: Use one of the predefined start modes.
+          example: Zero start
+          selector:
+            select:
+              options:
+                - Zero start
+                - Last known value
+                - Startup value
+    - name: Custom value
+      description: Custom output value to apply when no start mode is selected.
+      fields:
+        value:
+          name: Value
+          description: Custom output value to apply when no start mode is provided.
+          example: 10
+          selector:
+            number:
+              mode: box

--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -22,6 +22,4 @@ set_output:
       example: 10
       selector:
         number:
-          min: -100
-          max: 100
-          step: 1
+          mode: box

--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -1,0 +1,27 @@
+set_output:
+  name: Set PID output
+  description: Reset the PID controller and set its output to the selected value.
+  target:
+    entity:
+      integration: simple_pid_controller
+      domain: sensor
+  fields:
+    start_mode:
+      name: Start mode
+      description: Use one of the predefined start modes.
+      example: Zero start
+      selector:
+        select:
+          options:
+            - Zero start
+            - Last known value
+            - Startup value
+    value:
+      name: Value
+      description: Custom output value to apply when no start_mode is provided.
+      example: 10
+      selector:
+        number:
+          min: -100
+          max: 100
+          step: 1

--- a/tests/test_service_set_output.py
+++ b/tests/test_service_set_output.py
@@ -63,6 +63,21 @@ async def test_set_output_value_out_of_range(hass, config_entry):
 
 @pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
+async def test_set_output_both_values_fail(hass, config_entry):
+    """Providing both start_mode and value should raise an error."""
+    entity_id = f"sensor.{config_entry.entry_id}_pid_output"
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_OUTPUT,
+            {"start_mode": "Zero start", "value": 5.0},
+            target={"entity_id": entity_id},
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
 async def test_set_output_respects_zero_min(hass, config_entry):
     """Ensure zero output_min doesn't fall back to range minimum."""
     entity_id = f"sensor.{config_entry.entry_id}_pid_output"

--- a/tests/test_service_set_output.py
+++ b/tests/test_service_set_output.py
@@ -14,7 +14,8 @@ async def test_set_output_start_mode(hass, config_entry):
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_OUTPUT,
-        {"entity_id": entity_id, "start_mode": "Startup value"},
+        {"start_mode": "Startup value"},
+        target={"entity_id": entity_id},
         blocking=True,
     )
 
@@ -32,7 +33,8 @@ async def test_set_output_custom_value(hass, config_entry):
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_OUTPUT,
-        {"entity_id": entity_id, "value": 7.5},
+        {"value": 7.5},
+        target={"entity_id": entity_id},
         blocking=True,
     )
 

--- a/tests/test_service_set_output.py
+++ b/tests/test_service_set_output.py
@@ -1,0 +1,43 @@
+import pytest
+
+from custom_components.simple_pid_controller import DOMAIN, SERVICE_SET_OUTPUT
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
+async def test_set_output_start_mode(hass, config_entry):
+    """Service sets output based on start mode."""
+    entity_id = f"sensor.{config_entry.entry_id}_pid_output"
+    handle = config_entry.runtime_data.handle
+    handle.get_number = lambda key: {"starting_output": 42.0}.get(key)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_OUTPUT,
+        {"entity_id": entity_id, "start_mode": "Startup value"},
+        blocking=True,
+    )
+
+    assert handle.last_known_output == 42.0
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert float(state.state) == 42.0
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
+async def test_set_output_custom_value(hass, config_entry):
+    """Service sets output to provided custom value."""
+    entity_id = f"sensor.{config_entry.entry_id}_pid_output"
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_OUTPUT,
+        {"entity_id": entity_id, "value": 7.5},
+        blocking=True,
+    )
+
+    handle = config_entry.runtime_data.handle
+    assert handle.last_known_output == 7.5
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert float(state.state) == 7.5

--- a/tests/test_service_set_output.py
+++ b/tests/test_service_set_output.py
@@ -1,4 +1,5 @@
 import pytest
+import voluptuous as vol
 
 from custom_components.simple_pid_controller import DOMAIN, SERVICE_SET_OUTPUT
 
@@ -43,3 +44,18 @@ async def test_set_output_custom_value(hass, config_entry):
     state = hass.states.get(entity_id)
     assert state is not None
     assert float(state.state) == 7.5
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
+async def test_set_output_value_out_of_range(hass, config_entry):
+    """Service raises error when value is outside configured range."""
+    entity_id = f"sensor.{config_entry.entry_id}_pid_output"
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_OUTPUT,
+            {"value": 150.0},
+            target={"entity_id": entity_id},
+            blocking=True,
+        )


### PR DESCRIPTION
## Summary
- add `set_output` service to reset PID and set its output
- allow selecting PID output entity in service UI
- document service for UI usage
- test service for start modes and custom values
- document `set_output` service in README
- align service with quality scale by naming fields and using a target selector

## Testing
- `pre-commit run --files custom_components/simple_pid_controller/__init__.py custom_components/simple_pid_controller/services.yaml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cca7e5d6c8323a6b9a52b0f209a92