### PR TITLE
Support target-based entity for set_output service

### DIFF
--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -157,7 +157,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not hass.services.has_service(DOMAIN, SERVICE_SET_OUTPUT):
 
         async def async_set_output(call: ServiceCall) -> None:
-            entity_id = call.data[ATTR_ENTITY_ID]
+            entity_id = call.data[ATTR_ENTITY_ID][0]
             start_mode = call.data.get("start_mode")
             value = call.data.get("value")
 
@@ -197,7 +197,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             schema=vol.All(
                 vol.Schema(
                     {
-                        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+                        vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
                         vol.Optional("start_mode"): vol.In(START_MODE_OPTIONS),
                         vol.Optional("value"): vol.Coerce(float),
                     }

--- a/tests/test_service_set_output.py
+++ b/tests/test_service_set_output.py
@@ -14,7 +14,8 @@ async def test_set_output_start_mode(hass, config_entry):
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_OUTPUT,
-        {"entity_id": entity_id, "start_mode": "Startup value"},
+        {"start_mode": "Startup value"},
+        target={"entity_id": entity_id},
         blocking=True,
     )
 
@@ -32,7 +33,8 @@ async def test_set_output_custom_value(hass, config_entry):
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_OUTPUT,
-        {"entity_id": entity_id, "value": 7.5},
+        {"value": 7.5},
+        target={"entity_id": entity_id},
         blocking=True,
     )
 


### PR DESCRIPTION
## Summary
- Allow `set_output` service to accept `entity_id` from `target`
- Update tests for target-style service calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d7bf6002083238db3b9d6935329fa