### PR TITLE
Use input box for set_output and enforce output range

### DIFF
--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -182,6 +182,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             elif start_mode == "Startup value":
                 output = handle.get_number("starting_output") or 0.0
             else:
+                out_min = handle.get_number("output_min") or handle.output_range_min
+                out_max = handle.get_number("output_max") or handle.output_range_max
+                if value is None:
+                    raise vol.Invalid("Value must be provided when no start_mode is set")
+                if value < out_min or value > out_max:
+                    raise vol.Invalid(
+                        f"value {value} outside output range [{out_min}, {out_max}]"
+                    )
                 output = value
 
             handle.pid.reset()

--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -22,6 +22,4 @@ set_output:
       example: 10
       selector:
         number:
-          min: -100
-          max: 100
-          step: 1
+          mode: box

--- a/tests/test_service_set_output.py
+++ b/tests/test_service_set_output.py
@@ -1,4 +1,5 @@
 import pytest
+import voluptuous as vol
 
 from custom_components.simple_pid_controller import DOMAIN, SERVICE_SET_OUTPUT
 
@@ -43,3 +44,18 @@ async def test_set_output_custom_value(hass, config_entry):
     state = hass.states.get(entity_id)
     assert state is not None
     assert float(state.state) == 7.5
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
+async def test_set_output_value_out_of_range(hass, config_entry):
+    """Service raises error when value is outside configured range."""
+    entity_id = f"sensor.{config_entry.entry_id}_pid_output"
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_OUTPUT,
+            {"value": 150.0},
+            target={"entity_id": entity_id},
+            blocking=True,
+        )


### PR DESCRIPTION
## Summary
- replace slider with input box for `set_output` service
- validate service `value` against configured output range and add coverage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d7fd8b50c832397c9bcff8b6c439d