### PR TITLE
Respect configured output range when forcing PID output

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Reset the PID controller and force its output to a specific value.
 Parameters:
 - **entity_id** – PID output sensor to control.
 - **start_mode** – optional; one of `Zero start`, `Last known value`, or `Startup value`.
-- **value** – optional; custom numeric output (-100 to 100) used when no start mode is selected.
+- **value** – optional; custom numeric output used when no start mode is selected. The value must fall within the current Output Min and Output Max range (default 0–100).
 
 Either `start_mode` or `value` must be provided.
 

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -182,8 +182,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             elif start_mode == "Startup value":
                 output = handle.get_number("starting_output") or 0.0
             else:
-                out_min = handle.get_number("output_min") or handle.output_range_min
-                out_max = handle.get_number("output_max") or handle.output_range_max
+                out_min = handle.get_number("output_min")
+                if out_min is None:
+                    out_min = handle.output_range_min
+                out_max = handle.get_number("output_max")
+                if out_max is None:
+                    out_max = handle.output_range_max
                 if value is None:
                     raise vol.Invalid(
                         "Value must be provided when no start_mode is set"

--- a/custom_components/simple_pid_controller/sensor.py
+++ b/custom_components/simple_pid_controller/sensor.py
@@ -37,7 +37,10 @@ async def async_setup_entry(
     # Init PID with default values
     handle.pid = PID(1.0, 0.1, 0.05, setpoint=50, sample_time=None, auto_mode=False)
 
-    handle.pid.output_limits = (-10.0, 10.0)
+    handle.pid.output_limits = (
+        handle.output_range_min,
+        handle.output_range_max,
+    )
     handle.last_contributions = (0, 0, 0, 0)
     handle.last_known_output = None
 


### PR DESCRIPTION
## Summary
- use configured Output Min/Max when validating `set_output`
- initialize PID with configured output range
- document dynamic output range for `set_output`
- add regression test for zero output_min

## Testing
- `pre-commit run --files README.md custom_components/simple_pid_controller/__init__.py custom_components/simple_pid_controller/sensor.py tests/test_service_set_output.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d81b3fbfc8323b3750c0d2459629e