### PR TITLE
Enforce exclusive start mode or value for set_output service

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Parameters:
 - **start_mode** – optional; one of `Zero start`, `Last known value`, or `Startup value`.
 - **value** – optional; custom numeric output used when no start mode is selected. The value must fall within the current Output Min and Output Max range (default 0–100).
 
-Either `start_mode` or `value` must be provided.
+Exactly one of `start_mode` or `value` must be provided.
 
 This service can be called from Developer Tools → Services or from automations. Examples:
 

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -212,8 +212,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 vol.Schema(
                     {
                         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-                        vol.Optional("start_mode"): vol.In(START_MODE_OPTIONS),
-                        vol.Optional("value"): vol.Coerce(float),
+                        vol.Exclusive("start_mode", "set_output"): vol.In(
+                            START_MODE_OPTIONS
+                        ),
+                        vol.Exclusive("value", "set_output"): vol.Coerce(float),
                     }
                 ),
                 cv.has_at_least_one_key("start_mode", "value"),

--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -5,21 +5,27 @@ set_output:
     entity:
       integration: simple_pid_controller
       domain: sensor
-  fields:
-    start_mode:
-      name: Start mode
+  oneOf:
+    - name: Start mode
       description: Use one of the predefined start modes.
-      example: Zero start
-      selector:
-        select:
-          options:
-            - Zero start
-            - Last known value
-            - Startup value
-    value:
-      name: Value
-      description: Custom output value to apply when no start_mode is provided.
-      example: 10
-      selector:
-        number:
-          mode: box
+      fields:
+        start_mode:
+          name: Start mode
+          description: Use one of the predefined start modes.
+          example: Zero start
+          selector:
+            select:
+              options:
+                - Zero start
+                - Last known value
+                - Startup value
+    - name: Custom value
+      description: Custom output value to apply when no start mode is selected.
+      fields:
+        value:
+          name: Value
+          description: Custom output value to apply when no start mode is provided.
+          example: 10
+          selector:
+            number:
+              mode: box

--- a/tests/test_service_set_output.py
+++ b/tests/test_service_set_output.py
@@ -63,6 +63,21 @@ async def test_set_output_value_out_of_range(hass, config_entry):
 
 @pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
+async def test_set_output_both_values_fail(hass, config_entry):
+    """Providing both start_mode and value should raise an error."""
+    entity_id = f"sensor.{config_entry.entry_id}_pid_output"
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_OUTPUT,
+            {"start_mode": "Zero start", "value": 5.0},
+            target={"entity_id": entity_id},
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
 async def test_set_output_respects_zero_min(hass, config_entry):
     """Ensure zero output_min doesn't fall back to range minimum."""
     entity_id = f"sensor.{config_entry.entry_id}_pid_output"


### PR DESCRIPTION
## Summary
- Use `oneOf` in services.yaml so UI presents start mode or custom value choice
- Validate service schema with `vol.Exclusive` to prevent both fields at once
- Document exclusivity and add tests

## Testing
- `pre-commit run --files README.md custom_components/simple_pid_controller/__init__.py custom_components/simple_pid_controller/services.yaml tests/test_service_set_output.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d8489f968832398a23b9286fd3186