### PR TITLE
Add service to set PID output

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,23 @@ The integration provides a `simple_pid_controller.set_output` service to adjust 
 ### `simple_pid_controller.set_output`
 | Field | Description |
 |-------|-------------|
-| `entity_id` | PID output sensor entity to control |
+| `entity_id` | PID output sensor entity to control (may be provided via `target`) |
 | `preset` | Optional preset: `zero_start`, `last_known_value`, or `startup_value` |
 | `value` | Optional manual value between configured `Output Min` and `Output Max` |
 
 - When **Auto Mode** is off, the last output value is updated to the chosen value.
 - When **Auto Mode** is on, the PID restarts from the new value and the coordinator refreshes.
+- Exactly one PID output sensor entity must be targeted.
+
+Example using `target`:
+
+```yaml
+service: simple_pid_controller.set_output
+target:
+  entity_id: sensor.spid_x_pid_output
+data:
+  value: 200
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -191,12 +191,22 @@ The integration provides a `simple_pid_controller.set_output` service to adjust 
 ### `simple_pid_controller.set_output`
 | Field | Description |
 |-------|-------------|
-| `entity_id` | PID output sensor entity to control |
+| `entity_id` | PID output sensor entity to control (may be provided via `target`) |
 | `preset` | Optional preset: `zero_start`, `last_known_value`, or `startup_value` |
 | `value` | Optional manual value between configured `Output Min` and `Output Max` |
 
 - When **Auto Mode** is off, the last output value is updated to the chosen value.
 - When **Auto Mode** is on, the PID restarts from the new value and the coordinator refreshes.
+
+Example using `target`:
+
+```yaml
+action: simple_pid_controller.set_output
+target:
+  entity_id: sensor.spid_x_pid_output
+data:
+  value: 200
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,18 @@ Here's an example output showing the controller responding to a setpoint:
 
 ---
 
-## 🔧 Service Actions 
-This Integration does **not** expose any custom services. All interactions are performed via UI-based entities.
+## 🔧 Service Actions
+The integration provides a `simple_pid_controller.set_output` service to adjust the controller output directly.
+
+### `simple_pid_controller.set_output`
+| Field | Description |
+|-------|-------------|
+| `entity_id` | PID output sensor entity to control |
+| `preset` | Optional preset: `zero_start`, `last_known_value`, or `startup_value` |
+| `value` | Optional manual value between configured `Output Min` and `Output Max` |
+
+- When **Auto Mode** is off, the last output value is updated to the chosen value.
+- When **Auto Mode** is on, the PID restarts from the new value and the coordinator refreshes.
+
 
 

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import Platform, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -44,7 +44,7 @@ PRESET_OPTIONS = ["zero_start", "last_known_value", "startup_value"]
 
 SET_OUTPUT_SCHEMA = vol.Schema(
     {
-        vol.Required("entity_id"): cv.entity_id,
+        vol.Optional(ATTR_ENTITY_ID): cv.entity_id,
         vol.Optional(ATTR_VALUE): vol.Coerce(float),
         vol.Optional(ATTR_PRESET): vol.In(PRESET_OPTIONS),
     }
@@ -165,7 +165,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not hass.services.has_service(DOMAIN, SERVICE_SET_OUTPUT):
 
         async def async_set_output(call: ServiceCall) -> None:
-            entity_id: str = call.data["entity_id"]
+            entity_id: str | None = call.data.get(ATTR_ENTITY_ID)
+            if entity_id is None:
+                raise HomeAssistantError("entity_id is required")
             preset: str | None = call.data.get(ATTR_PRESET)
             value: float | None = call.data.get(ATTR_VALUE)
 

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -45,8 +45,8 @@ PRESET_OPTIONS = ["zero_start", "last_known_value", "startup_value"]
 SET_OUTPUT_SCHEMA = vol.Schema(
     {
         vol.Required("entity_id"): cv.entity_id,
-        vol.Exclusive(ATTR_VALUE, "target"): vol.Coerce(float),
-        vol.Exclusive(ATTR_PRESET, "target"): vol.In(PRESET_OPTIONS),
+        vol.Optional(ATTR_VALUE): vol.Coerce(float),
+        vol.Optional(ATTR_PRESET): vol.In(PRESET_OPTIONS),
     }
 )
 
@@ -179,7 +179,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             out_min = dev_handle.get_number("output_min") or 0.0
             out_max = dev_handle.get_number("output_max") or 0.0
 
-            if preset is None and value is None:
+            if (preset is None and value is None) or (
+                preset is not None and value is not None
+            ):
                 raise HomeAssistantError("Either preset or value required")
 
             if preset is not None:

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -204,6 +204,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             dev_handle.last_known_output = target
             coordinator: PIDDataCoordinator = config_entry.runtime_data.coordinator
             if dev_handle.pid.auto_mode:
+                dev_handle.pid.set_auto_mode(False)
                 dev_handle.pid.set_auto_mode(True, target)
                 await coordinator.async_request_refresh()
             else:

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -208,6 +208,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if dev_handle.pid.auto_mode:
                 dev_handle.pid.set_auto_mode(False)
                 dev_handle.pid.set_auto_mode(True, target)
+                coordinator.async_set_updated_data(target)
                 await coordinator.async_request_refresh()
             else:
                 coordinator.async_set_updated_data(target)

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -218,6 +218,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 await coordinator.async_request_refresh()
             else:
                 coordinator.async_set_updated_data(target)
+                # Update the internal PID output when in manual mode so that
+                # future calls to the controller return the newly set target.
+                dev_handle.pid._last_output = target
 
         hass.services.async_register(
             DOMAIN, SERVICE_SET_OUTPUT, async_set_output, schema=SET_OUTPUT_SCHEMA

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from dataclasses import dataclass
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+
 from .coordinator import PIDDataCoordinator
 
 from .const import (
@@ -33,6 +36,19 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.SELECT,
 ]
+
+SERVICE_SET_OUTPUT = "set_output"
+ATTR_VALUE = "value"
+ATTR_PRESET = "preset"
+PRESET_OPTIONS = ["zero_start", "last_known_value", "startup_value"]
+
+SET_OUTPUT_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Exclusive(ATTR_VALUE, "target"): vol.Coerce(float),
+        vol.Exclusive(ATTR_PRESET, "target"): vol.In(PRESET_OPTIONS),
+    }
+)
 
 
 @dataclass
@@ -68,6 +84,7 @@ class PIDDeviceHandle:
             CONF_SENSOR_ENTITY_ID, entry.data.get(CONF_SENSOR_ENTITY_ID)
         )
         self.last_contributions = (None, None, None)  # (P, I, D)
+        self.last_known_output = None
 
     def _get_entity_id(self, platform: str, key: str) -> str | None:
         """Lookup the real entity_id in the registry by unique_id == '<entry_id>_<key>'."""
@@ -145,6 +162,56 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     handle = PIDDeviceHandle(hass, entry)
     entry.runtime_data = MyData(handle=handle)
 
+    if not hass.services.has_service(DOMAIN, SERVICE_SET_OUTPUT):
+        async def async_set_output(call: ServiceCall) -> None:
+            entity_id: str = call.data["entity_id"]
+            preset: str | None = call.data.get(ATTR_PRESET)
+            value: float | None = call.data.get(ATTR_VALUE)
+
+            registry = er.async_get(hass)
+            ent = registry.async_get(entity_id)
+            if ent is None:
+                raise HomeAssistantError(f"Unknown entity {entity_id}")
+            config_entry = hass.config_entries.async_get_entry(ent.config_entry_id)
+            if config_entry is None or config_entry.runtime_data is None:
+                raise HomeAssistantError("PID controller not loaded")
+            dev_handle: PIDDeviceHandle = config_entry.runtime_data.handle
+            out_min = dev_handle.get_number("output_min") or 0.0
+            out_max = dev_handle.get_number("output_max") or 0.0
+
+            if preset is None and value is None:
+                raise HomeAssistantError("Either preset or value required")
+
+            if preset is not None:
+                if preset == "zero_start":
+                    target = 0.0
+                elif preset == "last_known_value":
+                    target = dev_handle.last_known_output or 0.0
+                elif preset == "startup_value":
+                    target = dev_handle.get_number("starting_output") or 0.0
+                else:
+                    raise HomeAssistantError("Invalid preset")
+            else:
+                target = value
+                if target is None:
+                    raise HomeAssistantError("Value required")
+                if target < out_min or target > out_max:
+                    raise HomeAssistantError(
+                        f"Value {target} out of range {out_min}-{out_max}"
+                    )
+
+            dev_handle.last_known_output = target
+            coordinator: PIDDataCoordinator = config_entry.runtime_data.coordinator
+            if dev_handle.pid.auto_mode:
+                dev_handle.pid.set_auto_mode(True, target)
+                await coordinator.async_request_refresh()
+            else:
+                coordinator.async_set_updated_data(target)
+
+        hass.services.async_register(
+            DOMAIN, SERVICE_SET_OUTPUT, async_set_output, schema=SET_OUTPUT_SCHEMA
+        )
+
     # register updatelistener for optionsflow
     entry.async_on_unload(entry.add_update_listener(_async_update_options_listener))
 
@@ -157,6 +224,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         # reset runtime_data zodat tests slagen
         entry.runtime_data = None
+        if not hass.config_entries.async_entries(DOMAIN):
+            hass.services.async_remove(DOMAIN, SERVICE_SET_OUTPUT)
     return unload_ok
 
 

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -163,6 +163,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.runtime_data = MyData(handle=handle)
 
     if not hass.services.has_service(DOMAIN, SERVICE_SET_OUTPUT):
+
         async def async_set_output(call: ServiceCall) -> None:
             entity_id: str = call.data["entity_id"]
             preset: str | None = call.data.get(ATTR_PRESET)

--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -8,7 +8,7 @@ set_output:
   fields:
     preset:
       name: Preset
-      description: Use a preset output: zero_start, last_known_value or startup_value.
+      description: "Use a preset output: zero_start, last_known_value or startup_value."
       selector:
         select:
           options:

--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -1,0 +1,25 @@
+set_output:
+  name: Set PID output
+  description: Set or reset the PID controller output.
+  fields:
+    entity_id:
+      name: PID output sensor
+      description: Target PID controller entity.
+      selector:
+        entity:
+          domain: sensor
+    preset:
+      name: Preset
+      description: Use a preset output: zero_start, last_known_value or startup_value.
+      selector:
+        select:
+          options:
+            - zero_start
+            - last_known_value
+            - startup_value
+    value:
+      name: Value
+      description: Manual output value between output_min and output_max.
+      selector:
+        number:
+          step: 0.1

--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -1,13 +1,11 @@
 set_output:
   name: Set PID output
   description: Set or reset the PID controller output.
+  target:
+    entity:
+      integration: simple_pid_controller
+      domain: sensor
   fields:
-    entity_id:
-      name: PID output sensor
-      description: Target PID controller entity.
-      selector:
-        entity:
-          domain: sensor
     preset:
       name: Preset
       description: Use a preset output: zero_start, last_known_value or startup_value.

--- a/custom_components/simple_pid_controller/translations/en.json
+++ b/custom_components/simple_pid_controller/translations/en.json
@@ -77,4 +77,21 @@
 		}
     }
   }
+  ,
+  "services": {
+    "set_output": {
+      "name": "Set PID output",
+      "description": "Set or reset the PID controller output.",
+      "fields": {
+        "preset": {
+          "name": "Preset",
+          "description": "Use a preset output: zero_start, last_known_value or startup_value."
+        },
+        "value": {
+          "name": "Value",
+          "description": "Manual output value between output_min and output_max."
+        }
+      }
+    }
+  }
 }

--- a/custom_components/simple_pid_controller/translations/nl.json
+++ b/custom_components/simple_pid_controller/translations/nl.json
@@ -76,4 +76,21 @@
       }
     }
   }
+  ,
+  "services": {
+    "set_output": {
+      "name": "Stel PID-uitgang in",
+      "description": "Stelt de uitgang van de PID-regelaar in of reset deze.",
+      "fields": {
+        "preset": {
+          "name": "Voorinstelling",
+          "description": "Kies een startwaarde: zero_start, last_known_value of startup_value."
+        },
+        "value": {
+          "name": "Waarde",
+          "description": "Handmatige uitgangswaarde binnen output_min en output_max."
+        }
+      }
+    }
+  }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,9 @@ async def setup_integration(hass, config_entry):
     """Set up the integration automatically for each test."""
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+    yield
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
 
 
 @pytest.fixture

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock, AsyncMock, call
 from custom_components.simple_pid_controller.const import DOMAIN
 
 
@@ -58,5 +58,5 @@ async def test_set_output_preset_startup(monkeypatch, hass, config_entry):
     )
 
     assert handle.last_known_output == 0.4
-    mock_set.assert_called_with(True, 0.4)
+    assert mock_set.call_args_list == [call(False), call(True, 0.4)]
     assert mock_refresh.await_count == 1

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,62 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from custom_components.simple_pid_controller.const import DOMAIN
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
+async def test_set_output_manual(hass, config_entry):
+    handle = config_entry.runtime_data.handle
+    coordinator = config_entry.runtime_data.coordinator
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_output",
+        {
+            "entity_id": f"sensor.{config_entry.entry_id.lower()}_pid_output",
+            "value": 0.5,
+        },
+        blocking=True,
+    )
+
+    assert handle.last_known_output == 0.5
+    assert coordinator.data == 0.5
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
+async def test_set_output_preset_startup(monkeypatch, hass, config_entry):
+    handle = config_entry.runtime_data.handle
+    coordinator = config_entry.runtime_data.coordinator
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {
+            "entity_id": f"number.{config_entry.entry_id.lower()}_startup_value",
+            "value": 0.4,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert handle.get_number("starting_output") == 0.4
+
+    handle.pid.auto_mode = True
+    mock_set = MagicMock()
+    handle.pid.set_auto_mode = mock_set
+    mock_refresh = AsyncMock()
+    coordinator.async_request_refresh = mock_refresh
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_output",
+        {
+            "entity_id": f"sensor.{config_entry.entry_id.lower()}_pid_output",
+            "preset": "startup_value",
+        },
+        blocking=True,
+    )
+
+    assert handle.last_known_output == 0.4
+    mock_set.assert_called_with(True, 0.4)
+    assert mock_refresh.await_count == 1

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -22,6 +22,9 @@ async def test_set_output_manual(hass, config_entry):
 
     assert handle.last_known_output == 0.5
     assert coordinator.data == 0.5
+    # Ensure that the PID controller's internal output is updated when
+    # auto mode is disabled.
+    assert handle.pid._last_output == 0.5
 
 
 @pytest.mark.usefixtures("setup_integration")
@@ -44,6 +47,7 @@ async def test_set_output_manual_target(hass, config_entry):
 
     assert handle.last_known_output == 0.5
     assert coordinator.data == 0.5
+    assert handle.pid._last_output == 0.5
 
 
 @pytest.mark.usefixtures("setup_integration")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -25,6 +25,26 @@ async def test_set_output_manual(hass, config_entry):
 
 @pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
+async def test_set_output_manual_target(hass, config_entry):
+    handle = config_entry.runtime_data.handle
+    coordinator = config_entry.runtime_data.coordinator
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_output",
+        {"value": 0.5},
+        target={
+            "entity_id": f"sensor.{config_entry.entry_id.lower()}_pid_output",
+        },
+        blocking=True,
+    )
+
+    assert handle.last_known_output == 0.5
+    assert coordinator.data == 0.5
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
 async def test_set_output_preset_startup(monkeypatch, hass, config_entry):
     handle = config_entry.runtime_data.handle
     coordinator = config_entry.runtime_data.coordinator


### PR DESCRIPTION
## Summary
- allow PID output to be set via new `set_output` service
- document service and add translations
- add tests and service schema

## Testing
- `pytest tests/test_service.py::test_set_output_manual -q`

## Manual testing
<img width="2250" height="343" alt="image" src="https://github.com/user-attachments/assets/8b23b6f6-4c1f-4be4-b1ff-e376d26115dc" />