### PR TITLE
Fix reinitializing auto mode when setting output

### DIFF
--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -204,6 +204,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             dev_handle.last_known_output = target
             coordinator: PIDDataCoordinator = config_entry.runtime_data.coordinator
             if dev_handle.pid.auto_mode:
+                dev_handle.pid.set_auto_mode(False)
                 dev_handle.pid.set_auto_mode(True, target)
                 await coordinator.async_request_refresh()
             else:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock, AsyncMock, call
 from custom_components.simple_pid_controller.const import DOMAIN
 
 
@@ -58,5 +58,5 @@ async def test_set_output_preset_startup(monkeypatch, hass, config_entry):
     )
 
     assert handle.last_known_output == 0.4
-    mock_set.assert_called_with(True, 0.4)
+    assert mock_set.call_args_list == [call(False), call(True, 0.4)]
     assert mock_refresh.await_count == 1


### PR DESCRIPTION
## Summary
- Reset PID auto mode before re-enabling to apply new output target
- Update service test to expect auto mode toggle

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e2569e8148323ab08bb8b89a83869