### PR TITLE
Fix services.yaml for Hassfest validation

### DIFF
--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -1,13 +1,11 @@
 set_output:
   name: Set PID output
   description: Set or reset the PID controller output.
+  target:
+    entity:
+      integration: simple_pid_controller
+      domain: sensor
   fields:
-    entity_id:
-      name: PID output sensor
-      description: Target PID controller entity.
-      selector:
-        entity:
-          domain: sensor
     preset:
       name: Preset
       description: Use a preset output: zero_start, last_known_value or startup_value.


### PR DESCRIPTION
## Summary
- move service target configuration from field to `target.entity`

## Testing
- `pre-commit run --files custom_components/simple_pid_controller/services.yaml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e27ac055c832382bb3925339d6965