### PR TITLE
Quote colon in service description to fix YAML

### DIFF
--- a/custom_components/simple_pid_controller/services.yaml
+++ b/custom_components/simple_pid_controller/services.yaml
@@ -8,7 +8,7 @@ set_output:
   fields:
     preset:
       name: Preset
-      description: Use a preset output: zero_start, last_known_value or startup_value.
+      description: "Use a preset output: zero_start, last_known_value or startup_value."
       selector:
         select:
           options:


### PR DESCRIPTION
## Summary
- quote description string in services.yaml to avoid YAML parser error

## Testing
- `pre-commit run --files custom_components/simple_pid_controller/services.yaml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e29a5d1ec8323bbf97a98fa6f53ec