### PR TITLE
Allow set_output service to use target

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,22 @@ The integration provides a `simple_pid_controller.set_output` service to adjust 
 ### `simple_pid_controller.set_output`
 | Field | Description |
 |-------|-------------|
-| `entity_id` | PID output sensor entity to control |
+| `entity_id` | PID output sensor entity to control (may be provided via `target`) |
 | `preset` | Optional preset: `zero_start`, `last_known_value`, or `startup_value` |
 | `value` | Optional manual value between configured `Output Min` and `Output Max` |
 
 - When **Auto Mode** is off, the last output value is updated to the chosen value.
 - When **Auto Mode** is on, the PID restarts from the new value and the coordinator refreshes.
+
+Example using `target`:
+
+```yaml
+action: simple_pid_controller.set_output
+target:
+  entity_id: sensor.spid_x_pid_output
+data:
+  value: 200
+```
 
 
 

--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import Platform, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -44,7 +44,7 @@ PRESET_OPTIONS = ["zero_start", "last_known_value", "startup_value"]
 
 SET_OUTPUT_SCHEMA = vol.Schema(
     {
-        vol.Required("entity_id"): cv.entity_id,
+        vol.Optional(ATTR_ENTITY_ID): cv.entity_id,
         vol.Optional(ATTR_VALUE): vol.Coerce(float),
         vol.Optional(ATTR_PRESET): vol.In(PRESET_OPTIONS),
     }
@@ -165,7 +165,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not hass.services.has_service(DOMAIN, SERVICE_SET_OUTPUT):
 
         async def async_set_output(call: ServiceCall) -> None:
-            entity_id: str = call.data["entity_id"]
+            entity_id: str | None = call.data.get(ATTR_ENTITY_ID)
+            if entity_id is None:
+                raise HomeAssistantError("entity_id is required")
             preset: str | None = call.data.get(ATTR_PRESET)
             value: float | None = call.data.get(ATTR_VALUE)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -25,6 +25,26 @@ async def test_set_output_manual(hass, config_entry):
 
 @pytest.mark.usefixtures("setup_integration")
 @pytest.mark.asyncio
+async def test_set_output_manual_target(hass, config_entry):
+    handle = config_entry.runtime_data.handle
+    coordinator = config_entry.runtime_data.coordinator
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_output",
+        {"value": 0.5},
+        target={
+            "entity_id": f"sensor.{config_entry.entry_id.lower()}_pid_output",
+        },
+        blocking=True,
+    )
+
+    assert handle.last_known_output == 0.5
+    assert coordinator.data == 0.5
+
+
+@pytest.mark.usefixtures("setup_integration")
+@pytest.mark.asyncio
 async def test_set_output_preset_startup(monkeypatch, hass, config_entry):
     handle = config_entry.runtime_data.handle
     coordinator = config_entry.runtime_data.coordinator


### PR DESCRIPTION
## Summary
- allow `set_output` service to accept entity via `target`
- document example usage and add regression test

## Testing
- `pre-commit run --files custom_components/simple_pid_controller/__init__.py README.md tests/test_service.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ec540607883239cb909a256dd5401