### PR TITLE
Ensure manual PID output updates internal state

### DIFF
--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -218,6 +218,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 await coordinator.async_request_refresh()
             else:
                 coordinator.async_set_updated_data(target)
+                # Update the internal PID output when in manual mode so that
+                # future calls to the controller return the newly set target.
+                dev_handle.pid._last_output = target
 
         hass.services.async_register(
             DOMAIN, SERVICE_SET_OUTPUT, async_set_output, schema=SET_OUTPUT_SCHEMA

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -22,6 +22,9 @@ async def test_set_output_manual(hass, config_entry):
 
     assert handle.last_known_output == 0.5
     assert coordinator.data == 0.5
+    # Ensure that the PID controller's internal output is updated when
+    # auto mode is disabled.
+    assert handle.pid._last_output == 0.5
 
 
 @pytest.mark.usefixtures("setup_integration")
@@ -44,6 +47,7 @@ async def test_set_output_manual_target(hass, config_entry):
 
     assert handle.last_known_output == 0.5
     assert coordinator.data == 0.5
+    assert handle.pid._last_output == 0.5
 
 
 @pytest.mark.usefixtures("setup_integration")


### PR DESCRIPTION
## Summary
- update PID output when auto_mode is disabled
- test that manual set_output updates PID internal output

## Testing
- `pre-commit run --files custom_components/simple_pid_controller/__init__.py tests/test_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ecb6368a48323b961c1094c622d97