### PR TITLE
Add history tracking to PID diagnostics

### DIFF
--- a/custom_components/simple_pid_controller/__init__.py
+++ b/custom_components/simple_pid_controller/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.const import Platform, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import entity_registry as er
+from collections import deque
 from dataclasses import dataclass
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
@@ -85,6 +86,9 @@ class PIDDeviceHandle:
         )
         self.last_contributions = (None, None, None)  # (P, I, D)
         self.last_known_output = None
+        self.input_history: deque[float] = deque(maxlen=10)
+        self.output_history: deque[float] = deque(maxlen=10)
+        self.pid_parameter_history: deque[dict[str, float | None]] = deque(maxlen=10)
 
     def _get_entity_id(self, platform: str, key: str) -> str | None:
         """Lookup the real entity_id in the registry by unique_id == '<entry_id>_<key>'."""

--- a/custom_components/simple_pid_controller/diagnostics.py
+++ b/custom_components/simple_pid_controller/diagnostics.py
@@ -13,6 +13,17 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     handle = entry.runtime_data.handle
 
+    sensor_state = hass.states.get(handle.sensor_entity_id)
+    input_sensor_info: dict[str, Any] | None = None
+    if sensor_state is not None:
+        input_sensor_info = {
+            "entity_id": sensor_state.entity_id,
+            "state": sensor_state.state,
+            "attributes": dict(sensor_state.attributes),
+            "last_changed": sensor_state.last_changed.isoformat(),
+            "last_updated": sensor_state.last_updated.isoformat(),
+        }
+
     return {
         "entry_data": entry.as_dict(),
         "data": {
@@ -22,5 +33,11 @@ async def async_get_config_entry_diagnostics(
             "input_range_max": handle.input_range_max,
             "output_range_min": handle.output_range_min,
             "output_range_max": handle.output_range_max,
+            "input_sensor": input_sensor_info,
+            "history": {
+                "input": list(handle.input_history),
+                "output": list(handle.output_history),
+                "pid_parameters": list(handle.pid_parameter_history),
+            },
         },
     }

--- a/custom_components/simple_pid_controller/sensor.py
+++ b/custom_components/simple_pid_controller/sensor.py
@@ -47,6 +47,8 @@ async def async_setup_entry(
         if input_value is None:
             raise ValueError("Input sensor not available")
 
+        handle.input_history.append(input_value)
+
         # Read parameters from UI
         kp = handle.get_number("kp")
         ki = handle.get_number("ki")
@@ -64,6 +66,15 @@ async def async_setup_entry(
         # adapt PID settings
         handle.pid.tunings = (kp, ki, kd)
         handle.pid.setpoint = setpoint
+
+        handle.pid_parameter_history.append(
+            {
+                "kp": kp,
+                "ki": ki,
+                "kd": kd,
+                "setpoint": setpoint,
+            }
+        )
 
         if windup_protection:
             handle.pid.output_limits = (out_min, out_max)
@@ -89,6 +100,7 @@ async def async_setup_entry(
 
         # save last know output
         handle.last_known_output = output
+        handle.output_history.append(output)
 
         # save last I contribution
         last_i = handle.last_contributions[1]


### PR DESCRIPTION
## Summary
- track recent PID input, output, and parameter values for the PID handle
- expose the input sensor state and history in the diagnostics download

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d880ddbb24832388fe0c68549e9a37