### PR TITLE
Add electricity price forecast support

### DIFF
--- a/custom_components/simple_pid_controller/diagnostics.py
+++ b/custom_components/simple_pid_controller/diagnostics.py
@@ -29,6 +29,7 @@ async def async_get_config_entry_diagnostics(
         "data": {
             "name": handle.name,
             "sensor_entity_id": handle.sensor_entity_id,
+            "sensor_forecast": handle.get_forecast_series(),
             "input_range_min": handle.input_range_min,
             "input_range_max": handle.input_range_max,
             "output_range_min": handle.output_range_min,


### PR DESCRIPTION
## Summary
- parse sensor states with decimal commas and extract electricity price forecasts from the configured input sensor
- expose the parsed forecast data through the diagnostics payload for troubleshooting
- cover the new helper with tests for float coercion and forecast parsing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e53b8430fc83239091fef0c8593219