### PR TITLE
Fix setpoint decimal value handling in UI

### DIFF
--- a/custom_components/simple_pid_controller/number.py
+++ b/custom_components/simple_pid_controller/number.py
@@ -76,7 +76,7 @@ CONTROL_NUMBER_ENTITIES = [
         "name": "Setpoint",
         "key": "setpoint",
         "unit": "",
-        "step": 1.0,
+        "step": 0.01,
         "default": 0.5,
         "entity_category": None,
     },


### PR DESCRIPTION


## 📝 What’s Changed?

<!-- Briefly describe the main changes in this PR -->
- Changed setpoint step size from 1.0 to 0.01 to allow decimal inputs (e.g., 40.1, 40.25) without triggering UI validation errors. This matches the precision used by other time-based parameters and provides appropriate granularity for typical control scenarios.



## 🔍 Why is this Change Needed?

<!-- Explain the reason or motivation behind the change -->
- Fixes issue where entering decimal setpoint values would display red validation error in UI despite the value being accepted by backend.

## 🧪 How Was This Tested?

<!-- Describe how you tested the changes -->
- [ ] Added or updated unit tests
- [ ] Manually tested in development environment
- [X] CI/CD pipeline passed successfully

## ✅ Checklist

- [X] Code follows the style guide
- [X] All tests are passing
- [X] Documentation updated if needed
- [X] No breaking changes (or clearly documented)